### PR TITLE
トークンを使用してユーザーを取得する関数名をリポジトリと合わせる

### DIFF
--- a/controllers/repo_controller_test.go
+++ b/controllers/repo_controller_test.go
@@ -52,7 +52,7 @@ func (m *mockErrorRepoModels) GetReposByToken(_ string, first int, order string)
 	return models.RepoResp{}, errors.New(errorMessage)
 }
 
-func TestIndexByTokenControllers(t *testing.T) {
+func TestIndexByTokenRepoController(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	t.Run("Test with success response", func(t *testing.T) {
 		mockModels := &mockRepoModels{}

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -8,7 +8,7 @@ import (
 )
 
 type UserController interface {
-	Get(c *gin.Context)
+	GetByToken(c *gin.Context)
 }
 
 type userController struct {
@@ -19,7 +19,7 @@ func NewUserController(m models.UserModels) UserController {
 	return &userController{m}
 }
 
-func (uc userController) Get(c *gin.Context) {
+func (uc userController) GetByToken(c *gin.Context) {
 	// auth_middlewareを使用する際の処理
 	// token, exists := c.Get("token")
 	// if !exists {
@@ -39,7 +39,7 @@ func (uc userController) Get(c *gin.Context) {
 		return
 	}
 
-	u, err := uc.m.GetUser(token)
+	u, err := uc.m.GetUserByToken(token)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -13,7 +13,7 @@ import (
 
 type mockUserModels struct{}
 
-func (m *mockUserModels) GetUser(_ string) (models.UserResp, error) {
+func (m *mockUserModels) GetUserByToken(_ string) (models.UserResp, error) {
 	user := models.User{
 		Login:     "john_doe",
 		Name:      "John Doe",
@@ -33,12 +33,12 @@ func (m *mockUserModels) GetUser(_ string) (models.UserResp, error) {
 
 type mockErrorUserModels struct{}
 
-func (m *mockErrorUserModels) GetUser(_ string) (models.UserResp, error) {
+func (m *mockErrorUserModels) GetUserByToken(_ string) (models.UserResp, error) {
 	errorMessage := "Failed to user"
 	return models.UserResp{}, errors.New(errorMessage)
 }
 
-func TestGetUserControllers(t *testing.T) {
+func TestGetByTokenUserController(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	t.Run("Test with success response", func(t *testing.T) {
 		mockModels := &mockUserModels{}
@@ -50,7 +50,7 @@ func TestGetUserControllers(t *testing.T) {
 		// c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
-		controller.Get(c)
+		controller.GetByToken(c)
 
 		assert.Equal(t, http.StatusOK, res.Code)
 		expectedResponse := `{"data":{"viewer":{"login":"john_doe","name":"John Doe","url":"https://example.com/john_doe","avatarUrl":"https://example.com/avatar/john_doe.jpg"}}}`
@@ -67,7 +67,7 @@ func TestGetUserControllers(t *testing.T) {
 		// c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
-		controller.Get(c)
+		controller.GetByToken(c)
 
 		assert.Equal(t, http.StatusNotFound, res.Code)
 		expectedResponse := `{"error":"Failed to user"}`

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func init() {
 
 	user := api.Group("/user")
 	{
-		user.GET("", userController.Get)
+		user.GET("", userController.GetByToken)
 	}
 
 	repo := api.Group("/repo")

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetReposByTokenModels(t *testing.T) {
+func TestGetReposByTokenRepoModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	utils.InitEnv()
 	t.Run("Test with success response", func(t *testing.T) {

--- a/models/user.go
+++ b/models/user.go
@@ -10,7 +10,7 @@ import (
 )
 
 type UserModels interface {
-	GetUser(token string) (UserResp, error)
+	GetUserByToken(token string) (UserResp, error)
 }
 
 type userModels struct{}
@@ -36,7 +36,7 @@ type (
 	}
 )
 
-func (um *userModels) GetUser(token string) (UserResp, error) {
+func (um *userModels) GetUserByToken(token string) (UserResp, error) {
 	userResp := UserResp{}
 
 	query := `

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetUserModels(t *testing.T) {
+func TestGetUserByTokenUserModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	utils.InitEnv()
 	t.Run("Test with success response", func(t *testing.T) {
@@ -17,7 +17,7 @@ func TestGetUserModels(t *testing.T) {
 		token := os.Getenv("ACCESS_TOKEN")
 		models := NewUserModels()
 
-		u, err := models.GetUser(token)
+		u, err := models.GetUserByToken(token)
 		if err != nil {
 			t.Errorf("GetUser returned an error: %v", err)
 		}


### PR DESCRIPTION
# Issue
#10

# 概要
トークンを使用してユーザーを取得する関数名をリポジトリを取得した際の変更のものと一貫性を持たせる
テストの際に流れるログに一貫性を持たせる

