### PR TITLE
GitHubAPI経由でリポジトリ毎のissuesを取得する

### DIFF
--- a/.env.exsample
+++ b/.env.exsample
@@ -1,2 +1,8 @@
-SECRET_KEY = ""
+# your github app secret key
+SECRET_KEY = "" 
+# your github access token 
 ACCESS_TOKEN = ""
+# github repository owner name
+OWNER_NAME = "" 
+# github repository name
+REPO_NAME =  ""

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
             * get
         * repos 
             * get params -> first: min 1 max 100, order: ASC or DESC
+    * issue(with token)
+        * list 
+            * get params -> owner: owner name, repo: repository name, first: min 1 max 100, order: ASC or DESC, states: OPEN or CLOSE
 
 ## Local
 ### Run

--- a/controllers/issue_controller.go
+++ b/controllers/issue_controller.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"main/models"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type IssueController interface {
+	Index(c *gin.Context)
+}
+
+type issueController struct {
+	m models.IssueModel
+}
+
+func NewIssueController(m models.IssueModel) IssueController {
+	return &issueController{m}
+}
+
+type IssueReq struct {
+	Owner  string `form:"owner" binding:"required"`
+	Repo   string `form:"repo" binding:"required"`
+	First  int    `form:"first" binding:"required,max=100,min=1"`
+	Order  string `form:"order" binding:"required,oneof=ASC DESC"`
+	States string `form:"states" binding:"required,oneof=OPEN CLOSE"`
+}
+
+func (ic issueController) Index(c *gin.Context) {
+	// headerのtokenを取得
+	token := c.GetHeader("Authorization")
+	if token == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Error invalid authorization token",
+		})
+		return
+	}
+
+	issueReq := IssueReq{}
+
+	if err := c.ShouldBindQuery(&issueReq); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	i, err := ic.m.GetIssues(token, issueReq.Owner, issueReq.Repo, issueReq.First, issueReq.Order, issueReq.States)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, i)
+}

--- a/controllers/issue_controller_test.go
+++ b/controllers/issue_controller_test.go
@@ -1,0 +1,145 @@
+package controllers
+
+import (
+	"errors"
+	"main/models"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockIssueModel struct{}
+
+func (m *mockIssueModel) GetIssues(_ string, owner string, repo string, first int, order string, states string) (models.IssuesResp, error) {
+	issue := []models.Issue{
+		{
+			ID:        "IssueID1",
+			CreatedAt: "2000-01-01T00:00:00Z",
+			UpdatedAt: "2000-01-01T00:00:00Z",
+			State:     "OPEN",
+			URL:       "https://example.com/issue",
+			Title:     "First issue",
+			Number:    1,
+			Body:      "Body issue",
+			BodyHTML:  "Body issue",
+		},
+		{
+			ID:        "IssueID2",
+			CreatedAt: "2000-01-01T00:00:00Z",
+			UpdatedAt: "2000-01-01T00:00:00Z",
+			State:     "OPEN",
+			URL:       "https://example.com/issue",
+			Title:     "Second issue",
+			Number:    2,
+			Body:      "Body issue",
+			BodyHTML:  "Body issue",
+		},
+	}
+
+	resp := models.IssuesResp{
+		Data: models.IssueRepository{
+			Repository: models.Issues{
+				CreatedAt:     "2000-01-01T00:00:00Z",
+				UpdatedAt:     "2000-01-01T00:00:00Z",
+				Name:          "RepoName",
+				NameWithOwner: "Owner/RepoName",
+				Issues: models.IssueNodes{
+					Nodes: issue,
+				},
+			},
+		},
+	}
+
+	issuesResp := resp
+	return issuesResp, nil
+}
+
+type mockErrorIssueModel struct{}
+
+func (m *mockErrorIssueModel) GetIssues(_ string, owner string, repo string, first int, order string, states string) (models.IssuesResp, error) {
+	errorMessage := "Failed to issues"
+	return models.IssuesResp{}, errors.New(errorMessage)
+}
+
+func TestIndexIssueController(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Run("Test with success response", func(t *testing.T) {
+		mockModel := &mockIssueModel{}
+		controller := NewIssueController(mockModel)
+
+		res := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(res)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/issue/list?order=DESC&first=1&owner=aaa&repo=bbb&states=OPEN", nil)
+		c.Set("token", "token")
+		c.Request.Header.Set("Authorization", "Bearer")
+
+		controller.Index(c)
+
+		assert.Equal(t, http.StatusOK, res.Code)
+		expectedResponse := `{"data":{"repository":{"createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","name":"RepoName","nameWithOwner":"Owner/RepoName","issues":{"nodes":[{"id":"IssueID1","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","state":"OPEN","url":"https://example.com/issue","title":"First issue","number":1,"body":"Body issue","bodyHTML":"Body issue","comment":{"nodes":null}},{"id":"IssueID2","createdAt":"2000-01-01T00:00:00Z","updatedAt":"2000-01-01T00:00:00Z","state":"OPEN","url":"https://example.com/issue","title":"Second issue","number":2,"body":"Body issue","bodyHTML":"Body issue","comment":{"nodes":null}}]}}}}`
+		assert.Equal(t, expectedResponse, res.Body.String())
+	})
+
+	t.Run("Test with error response", func(t *testing.T) {
+		mockErrorModel := &mockErrorIssueModel{}
+		controller := NewIssueController(mockErrorModel)
+
+		res := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(res)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/issue/list?order=DESC&first=1&owner=aaa&repo=bbb&states=OPEN", nil)
+		c.Request.Header.Set("Authorization", "Bearer")
+
+		controller.Index(c)
+
+		assert.Equal(t, http.StatusNotFound, res.Code)
+		expectedResponse := `{"error":"Failed to issues"}`
+		assert.Equal(t, expectedResponse, res.Body.String())
+	})
+
+	argCases := []struct {
+		name   string
+		params string
+	}{
+		{
+			name:   "validate error handling for query order",
+			params: "order=AAA&first=1&owner=aaa&repo=bbb&states=OPEN",
+		},
+		{
+			name:   "validate error handling for query first",
+			params: "order=DESC&first=0&owner=aaa&repo=bbb&states=OPEN",
+		},
+		{
+			name:   "validate error handling for query owner",
+			params: "order=DESC&first=1&owner=&repo=bbb&states=OPEN",
+		},
+		{
+			name:   "validate error handling for query repo",
+			params: "order=DESC&first=1&owner=aaa&repo=&states=OPEN",
+		},
+		{
+			name:   "validate error handling for query states",
+			params: "order=DESC&first=1&owner=aaa&repo=bbb&states=AAA",
+		},
+	}
+
+	for _, tc := range argCases {
+		t.Run("Test "+tc.name, func(t *testing.T) {
+			mockModel := &mockIssueModel{}
+			controller := NewIssueController(mockModel)
+
+			res := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(res)
+			url := "/issue/list?" + tc.params
+			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
+			c.Request.Header.Set("Authorization", "Bearer")
+
+			controller.Index(c)
+
+			assert.Equal(t, http.StatusBadRequest, res.Code)
+		})
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,9 @@ func init() {
 	repoModel := models.NewRepoModel()
 	repoController := controllers.NewRepoController(repoModel)
 
+	issueModel := models.NewIssueModel()
+	issueController := controllers.NewIssueController(issueModel)
+
 	r = gin.Default()
 
 	// cors設定
@@ -57,6 +60,11 @@ func init() {
 	{
 		viewer.GET("/user", userController.GetByToken)
 		viewer.GET("/repos", repoController.IndexByToken)
+	}
+
+	issue := api.Group("/issue")
+	{
+		issue.GET("/list", issueController.Index)
 	}
 }
 

--- a/models/issue.go
+++ b/models/issue.go
@@ -1,0 +1,133 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"main/configs"
+	"net/http"
+	"strings"
+)
+
+type IssueModel interface {
+	GetIssues(token string, owner string, repo string, first int, order string, states string) (IssuesResp, error)
+}
+
+type issueModel struct{}
+
+func NewIssueModel() IssueModel {
+	return &issueModel{}
+}
+
+type (
+	IssuesResp struct {
+		Data IssueRepository `json:"data"`
+	}
+
+	IssueRepository struct {
+		Repository Issues `json:"repository"`
+	}
+
+	Issues struct {
+		CreatedAt     string     `json:"createdAt"`
+		UpdatedAt     string     `json:"updatedAt"`
+		Name          string     `json:"name"`
+		NameWithOwner string     `json:"nameWithOwner"`
+		Issues        IssueNodes `json:"issues"`
+	}
+
+	IssueNodes struct {
+		Nodes []Issue `json:"nodes"`
+	}
+
+	Issue struct {
+		ID        string       `json:"id"`
+		CreatedAt string       `json:"createdAt"`
+		UpdatedAt string       `json:"updatedAt"`
+		State     string       `json:"state"`
+		URL       string       `json:"url"`
+		Title     string       `json:"title"`
+		Number    int          `json:"number"`
+		Body      string       `json:"body"`
+		BodyHTML  string       `json:"bodyHTML"`
+		Comments  CommentNodes `json:"comment"`
+	}
+
+	CommentNodes struct {
+		Nodes []Comment `json:"nodes"`
+	}
+
+	Comment struct {
+		Body      string `json:"body"`
+		CreatedAt string `json:"createdAt"`
+	}
+)
+
+func (im *issueModel) GetIssues(token string, owner string, repo string, first int, order string, states string) (IssuesResp, error) {
+	issueResp := IssuesResp{}
+
+	query := `
+		query {
+			repository(name: "%s", owner: "%s") {
+				createdAt
+				updatedAt
+				name
+				nameWithOwner
+				issues(first: %d, states: %s, orderBy: { field: CREATED_AT, direction: %s }) {
+					nodes {
+						id
+						createdAt
+						updatedAt
+						state
+						url
+						title
+						number
+						body
+						bodyHTML
+					}
+				}
+			}
+		}
+	`
+
+	query = fmt.Sprintf(query, repo, owner, first, states, order)
+	val := map[string]string{"query": query}
+
+	data, err := json.Marshal(val)
+	if err != nil {
+		log.Println("Error marshal GraphQL query json:", err)
+		return issueResp, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, configs.GetGithubGraphQLEndPoint(), strings.NewReader(string(data)))
+	if err != nil {
+		log.Println("Error request github api:", err)
+		return issueResp, err
+	}
+
+	req.Header.Set("Authorization", token)
+	req.Header.Set("Context-type", "application/json")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		log.Println("Error do client:", err)
+		return issueResp, err
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Println("Error reading body:", err)
+		return issueResp, err
+	}
+
+	json.Unmarshal(body, &issueResp)
+
+	return issueResp, nil
+}

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"main/utils"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIssuesIssueModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	utils.InitEnv()
+	t.Run("Test with success response", func(t *testing.T) {
+		// テスト用に環境変数から各項目を取得
+		token := os.Getenv("ACCESS_TOKEN") // アクセストークン
+		owner := os.Getenv("OWNER_NAME")   // オーナーの名前
+		repo := os.Getenv("REPO_NAME")     // リポジトリーの名前
+		first := 5                         // 取得数
+		order := "DESC"                    // 取得順
+		states := "OPEN"                   // OPENかCLOSE
+
+		model := NewIssueModel()
+
+		i, err := model.GetIssues(token, owner, repo, first, order, states)
+		if err != nil {
+			t.Errorf("GetIssues returned an error: %v", err)
+		}
+
+		for _, v := range i.Data.Repository.Issues.Nodes {
+			assert.NotEqual(t, v.ID, "")
+			assert.NotEqual(t, v.CreatedAt, "")
+			assert.NotEqual(t, v.UpdatedAt, "")
+			assert.NotEqual(t, v.URL, "")
+			assert.NotEqual(t, v.State, "")
+			assert.NotEqual(t, v.Title, "")
+			assert.NotEqual(t, v.Number, "")
+			assert.NotEqual(t, v.Body, "")
+			assert.NotEqual(t, v.BodyHTML, "")
+		}
+	})
+}

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -15,8 +15,8 @@ func TestGetIssuesIssueModel(t *testing.T) {
 	t.Run("Test with success response", func(t *testing.T) {
 		// テスト用に環境変数から各項目を取得
 		token := os.Getenv("ACCESS_TOKEN") // アクセストークン
-		owner := os.Getenv("OWNER_NAME")   // オーナーの名前
-		repo := os.Getenv("REPO_NAME")     // リポジトリーの名前
+		owner := os.Getenv("OWNER_NAME")   // オーナー名
+		repo := os.Getenv("REPO_NAME")     // リポジトリ名
 		first := 5                         // 取得数
 		order := "DESC"                    // 取得順
 		states := "OPEN"                   // OPENかCLOSE


### PR DESCRIPTION
# Issue
#4

# 概要
GitHubAPIを使用してリポジトリのissueリストを取得する
必要なパラメーターは以下
- オーナー名
- リポジトリ名
- 取得数 
- 取得順(作成日で昇順か降順)
- イシューのステータス