### PR TITLE
modelsのテストでassert.NotEqualをassert.NotEmptyに変更する

### DIFF
--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -29,15 +29,15 @@ func TestGetIssuesIssueModel(t *testing.T) {
 		}
 
 		for _, v := range i.Data.Repository.Issues.Nodes {
-			assert.NotEqual(t, v.ID, "")
-			assert.NotEqual(t, v.CreatedAt, "")
-			assert.NotEqual(t, v.UpdatedAt, "")
-			assert.NotEqual(t, v.URL, "")
-			assert.NotEqual(t, v.State, "")
-			assert.NotEqual(t, v.Title, "")
-			assert.NotEqual(t, v.Number, "")
-			assert.NotEqual(t, v.Body, "")
-			assert.NotEqual(t, v.BodyHTML, "")
+			assert.NotEmpty(t, v.ID)
+			assert.NotEmpty(t, v.CreatedAt)
+			assert.NotEmpty(t, v.UpdatedAt)
+			assert.NotEmpty(t, v.URL)
+			assert.NotEmpty(t, v.State)
+			assert.NotEmpty(t, v.Title)
+			assert.NotEmpty(t, v.Number)
+			assert.NotEmpty(t, v.Body)
+			assert.NotEmpty(t, v.BodyHTML)
 		}
 	})
 }

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -26,10 +26,10 @@ func TestGetReposByTokenRepoModel(t *testing.T) {
 		}
 
 		for _, v := range r.Data.Viewer.Repositories.Nodes {
-			assert.NotEqual(t, v.Name, "")
-			assert.NotEqual(t, v.URL, "")
-			assert.NotEqual(t, v.CreatedAt, "")
-			assert.NotEqual(t, v.UpdatedAt, "")
+			assert.NotEmpty(t, v.Name)
+			assert.NotEmpty(t, v.URL)
+			assert.NotEmpty(t, v.CreatedAt)
+			assert.NotEmpty(t, v.UpdatedAt)
 		}
 	})
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -22,9 +22,9 @@ func TestGetUserByTokenUserModel(t *testing.T) {
 			t.Errorf("GetUser returned an error: %v", err)
 		}
 
-		assert.NotEqual(t, u.Data.Viewer.Login, "")
-		assert.NotEqual(t, u.Data.Viewer.Name, "")
-		assert.NotEqual(t, u.Data.Viewer.URL, "")
-		assert.NotEqual(t, u.Data.Viewer.AvatarUrl, "")
+		assert.NotEmpty(t, u.Data.Viewer.Login)
+		assert.NotEmpty(t, u.Data.Viewer.Name)
+		assert.NotEmpty(t, u.Data.Viewer.URL)
+		assert.NotEmpty(t, u.Data.Viewer.AvatarUrl)
 	})
 }


### PR DESCRIPTION
# Issue
#19

# 概要
空文字列と比較していたところを
レスポンスが空だとテスト失敗になるように変更