### PR TITLE
リポジトリが100件以上ある際を考慮した処理に変更

### DIFF
--- a/controllers/repo_controller.go
+++ b/controllers/repo_controller.go
@@ -21,7 +21,8 @@ func NewRepoController(m models.RepoModel) RepoController {
 
 type RepoReq struct {
 	First int    `form:"first" binding:"required,max=100,min=1"`
-	Order string `form:"order" binding:"required,oneof=ASC DESC"`
+	Order string `form:"order" binding:"omitempty,oneof=ASC DESC"`
+	After string `form:"after"`
 }
 
 func (rc repoController) IndexByToken(c *gin.Context) {
@@ -43,7 +44,7 @@ func (rc repoController) IndexByToken(c *gin.Context) {
 		return
 	}
 
-	r, err := rc.m.GetReposByToken(token, repoReq.First, repoReq.Order)
+	r, err := rc.m.GetReposByToken(token, repoReq.First, repoReq.Order, repoReq.After)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/models/repo_test.go
+++ b/models/repo_test.go
@@ -13,14 +13,14 @@ func TestGetReposByTokenRepoModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	utils.InitEnv()
 	t.Run("Test with success response", func(t *testing.T) {
-		// テスト用に環境変数からアクセストークンを取得
-		token := os.Getenv("ACCESS_TOKEN")
-		first := 5      // 取得数
-		order := "DESC" // 取得順
+		token := os.Getenv("ACCESS_TOKEN") // アクセストークン
+		first := 5                         // 取得数
+		order := "DESC"                    // 取得順
+		after := ""                        // 次ページ取得
 
 		model := NewRepoModel()
 
-		r, err := model.GetReposByToken(token, first, order)
+		r, err := model.GetReposByToken(token, first, order, after)
 		if err != nil {
 			t.Errorf("GetReposByToken returned an error: %v", err)
 		}


### PR DESCRIPTION
# Issue
#17

# 概要
pageinfoを取得して指定された件数より多い場合、取得できるように変更
クエリ変更しvariablesを使用するようにする

# 備考
variablesを使用する変更にあたりQueryParamを指定しなかった際のデフォルト値を設定