### PR TITLE
イシューが100件以上ある際を考慮した処理に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,33 @@
 * Gin v1.9.0
 * GitHubAPI
 ## API
-* api
-    * viewer(with token)
-        * user
-            * get
-        * repos 
-            * get params -> first: min 1 max 100, order: ASC or DESC
-    * issue(with token)
-        * list 
-            * get params -> owner: owner name, repo: repository name, first: min 1 max 100, order: ASC or DESC, states: OPEN or CLOSE
+Local End Point  
+```
+http://localhost:8080/api
+```
+
+header with access token
+### /viewer  
+
+* GET /user  
+
+* GET /repos  
+
+param|required|default|description
+|--|--|--|--|
+first|true|| min 1 max 100
+order||DESC| ASC or DESC
+
+### /issue
+* GET /list  
+
+param|required|default|description
+|--|--|--|--|
+first|true|| min 1 max 100
+owner|true|| owner name
+repo|true|| repository name
+order||DESC| ASC or DESC
+states||OPEN| OPEN or CLOSE
 
 ## Local
 ### Run

--- a/controllers/issue_controller.go
+++ b/controllers/issue_controller.go
@@ -23,8 +23,9 @@ type IssueReq struct {
 	Owner  string `form:"owner" binding:"required"`
 	Repo   string `form:"repo" binding:"required"`
 	First  int    `form:"first" binding:"required,max=100,min=1"`
-	Order  string `form:"order" binding:"required,oneof=ASC DESC"`
-	States string `form:"states" binding:"required,oneof=OPEN CLOSE"`
+	Order  string `form:"order" binding:"omitempty,oneof=ASC DESC"`
+	States string `form:"states" binding:"omitempty,oneof=OPEN CLOSE"`
+	After  string `form:"after"`
 }
 
 func (ic issueController) Index(c *gin.Context) {
@@ -46,7 +47,7 @@ func (ic issueController) Index(c *gin.Context) {
 		return
 	}
 
-	i, err := ic.m.GetIssues(token, issueReq.Owner, issueReq.Repo, issueReq.First, issueReq.Order, issueReq.States)
+	i, err := ic.m.GetIssues(token, issueReq.Owner, issueReq.Repo, issueReq.First, issueReq.Order, issueReq.States, issueReq.After)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/models/issue_test.go
+++ b/models/issue_test.go
@@ -20,10 +20,11 @@ func TestGetIssuesIssueModel(t *testing.T) {
 		first := 5                         // 取得数
 		order := "DESC"                    // 取得順
 		states := "OPEN"                   // OPENかCLOSE
+		after := ""                        // 次ページ取得
 
 		model := NewIssueModel()
 
-		i, err := model.GetIssues(token, owner, repo, first, order, states)
+		i, err := model.GetIssues(token, owner, repo, first, order, states, after)
 		if err != nil {
 			t.Errorf("GetIssues returned an error: %v", err)
 		}


### PR DESCRIPTION
# Issue
#18

# 概要
pageinfoを取得して指定された件数より多い場合、取得できるように変更
クエリ変更しvariablesを使用するようにする

# 備考
variablesを使用する変更にあたりQueryParamを指定しなかった際のデフォルト値を設定