### PR TITLE
一時コードからTokenを取得する処理の作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go fmt && go build -o app .
 
 CMD ["./app"]
 
-FROM golang:1.20 AS dev
+FROM golang:1.20 AS local
 
 WORKDIR /go/src/work
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Local End Point
 http://localhost:8080/api
 ```
 
-header with access token
+### /auth
+
+* GET /
+
+param|required|default|description
+|--|--|--|--|
+code|true|| temporary code issued by the GitHub
+
 ### /viewer  
 
 * GET /user  
@@ -64,4 +71,8 @@ labelIds||| issue label id array
 1. `docker exec -it github_api_container bash`
 2. `gotest -v ./...`
 
+### GetLocalToken
+local環境で.envに開発用のアクセストークンを設定した状態で  
+`/api/auth/test`にアクセスすると、Local用トークンがcookieに設定され返却されます
+>http://localhost:8080/api/auth/test
 

--- a/configs/config.go
+++ b/configs/config.go
@@ -1,7 +1,23 @@
 package configs
 
 var githubGraphQLEndPoint = "https://api.github.com/graphql"
+var githubAccessTokenEndPoint = "https://github.com/login/oauth/access_token"
+
+var localHost = "http://localhost:5173"
+var host = ""
 
 func GetGithubGraphQLEndPoint() string {
 	return githubGraphQLEndPoint
+}
+
+func GetGithubAccessTokenEndPoint() string {
+	return githubAccessTokenEndPoint
+}
+
+func GetLocalHost() string {
+	return localHost
+}
+
+func GetHost() string {
+	return host
 }

--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -42,8 +42,9 @@ func (ac *authController) Get(c *gin.Context) {
 	}
 
 	cookie := &http.Cookie{
-		Name:  "Token",
-		Value: cases.Title(language.Und).String(t.TokenType) + " " + t.AccessToken, Path: "/",
+		Name:     "Token",
+		Value:    cases.Title(language.Und).String(t.TokenType) + " " + t.AccessToken,
+		Path:     "/",
 		Expires:  time.Now().Add(24 * time.Hour),
 		HttpOnly: true,
 	}

--- a/controllers/auth_controller.go
+++ b/controllers/auth_controller.go
@@ -1,0 +1,54 @@
+package controllers
+
+import (
+	"main/models"
+	"main/types"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+type AuthController interface {
+	Get(c *gin.Context)
+}
+
+type authController struct {
+	m models.AuthModel
+}
+
+func NewAuthController(m models.AuthModel) AuthController {
+	return &authController{m}
+}
+
+func (ac *authController) Get(c *gin.Context) {
+	authReq := types.AuthReq{}
+
+	if err := c.ShouldBindQuery(&authReq); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	t, err := ac.m.GetToken(authReq)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	cookie := &http.Cookie{
+		Name:  "Token",
+		Value: cases.Title(language.Und).String(t.TokenType) + " " + t.AccessToken, Path: "/",
+		Expires:  time.Now().Add(24 * time.Hour),
+		HttpOnly: true,
+	}
+
+	http.SetCookie(c.Writer, cookie)
+
+	c.JSON(http.StatusOK, "success get token")
+}

--- a/controllers/auth_controller_test.go
+++ b/controllers/auth_controller_test.go
@@ -1,0 +1,88 @@
+package controllers
+
+import (
+	"errors"
+	"main/types"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockAuthModel struct{}
+
+func (m *mockAuthModel) GetToken(types.AuthReq) (types.AuthRes, error) {
+	res := types.AuthRes{
+		AccessToken: "abcde12345",
+		TokenType:   "Bearer",
+		Scope:       "repo",
+	}
+
+	return res, nil
+}
+
+type mockErrorAuthModel struct{}
+
+func (m *mockErrorAuthModel) GetToken(types.AuthReq) (types.AuthRes, error) {
+	return types.AuthRes{}, errors.New("Failed to token")
+}
+
+func TestGetAuthController(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Run("Test with success response", func(t *testing.T) {
+		mockModel := &mockAuthModel{}
+		controller := NewAuthController(mockModel)
+
+		res := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(res)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/auth?code=abcdefg12345", nil)
+
+		controller.Get(c)
+
+		assert.Equal(t, http.StatusOK, res.Code)
+	})
+
+	t.Run("Test with error response", func(t *testing.T) {
+		mockErrorModel := &mockErrorAuthModel{}
+		controller := NewAuthController(mockErrorModel)
+
+		res := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(res)
+		c.Request, _ = http.NewRequest(http.MethodGet, "/auth?code=abcdefg12345", nil)
+
+		controller.Get(c)
+
+		assert.Equal(t, http.StatusNotFound, res.Code)
+		expectedResponse := `{"error":"Failed to token"}`
+		assert.Equal(t, expectedResponse, res.Body.String())
+	})
+
+	// QueryParam
+	paramCases := []struct {
+		name   string
+		params string
+	}{
+		{
+			name:   "validate error handling for query code",
+			params: "code=",
+		},
+	}
+
+	for _, tc := range paramCases {
+		t.Run("Test "+tc.name, func(t *testing.T) {
+			mockModel := &mockAuthModel{}
+			controller := NewAuthController(mockModel)
+
+			res := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(res)
+			url := "/auth?" + tc.params
+			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
+
+			controller.Get(c)
+
+			assert.Equal(t, http.StatusBadRequest, res.Code)
+		})
+	}
+}

--- a/controllers/issue_controller.go
+++ b/controllers/issue_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"main/models"
 	"main/types"
 	"net/http"
@@ -23,14 +24,14 @@ func NewIssueController(m models.IssueModel) IssueController {
 }
 
 func (ic *issueController) Index(c *gin.Context) {
-	// headerのtokenを取得
-	token := c.GetHeader("Authorization")
-	if token == "" {
+	token, exists := c.Get("token")
+	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Error invalid authorization token",
+			"error": "Error invalid token",
 		})
 		return
 	}
+	sToken := fmt.Sprint(token)
 
 	issuesReq := types.IssuesReq{}
 
@@ -41,7 +42,7 @@ func (ic *issueController) Index(c *gin.Context) {
 		return
 	}
 
-	i, err := ic.m.GetIssues(token, issuesReq)
+	i, err := ic.m.GetIssues(sToken, issuesReq)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),
@@ -53,14 +54,14 @@ func (ic *issueController) Index(c *gin.Context) {
 }
 
 func (ic *issueController) Get(c *gin.Context) {
-	// headerのtokenを取得
-	token := c.GetHeader("Authorization")
-	if token == "" {
+	token, exists := c.Get("token")
+	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Error invalid authorization token",
+			"error": "Error invalid token",
 		})
 		return
 	}
+	sToken := fmt.Sprint(token)
 
 	issueReq := types.IssueReq{}
 
@@ -71,7 +72,7 @@ func (ic *issueController) Get(c *gin.Context) {
 		return
 	}
 
-	i, err := ic.m.GetIssue(token, issueReq)
+	i, err := ic.m.GetIssue(sToken, issueReq)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),
@@ -83,14 +84,14 @@ func (ic *issueController) Get(c *gin.Context) {
 }
 
 func (ic *issueController) Create(c *gin.Context) {
-	// headerのtokenを取得
-	token := c.GetHeader("Authorization")
-	if token == "" {
+	token, exists := c.Get("token")
+	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Error invalid authorization token",
+			"error": "Error invalid token",
 		})
 		return
 	}
+	sToken := fmt.Sprint(token)
 
 	issueCreateReq := types.IssueCreateReq{}
 
@@ -101,7 +102,7 @@ func (ic *issueController) Create(c *gin.Context) {
 		return
 	}
 
-	i, err := ic.m.CreateIssue(token, issueCreateReq)
+	i, err := ic.m.CreateIssue(sToken, issueCreateReq)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/controllers/issue_controller_test.go
+++ b/controllers/issue_controller_test.go
@@ -130,7 +130,6 @@ func TestIndexIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue/list?first=1&order=DESC&owner=aaa&repo=bbb&states=OPEN", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Index(c)
 
@@ -145,7 +144,6 @@ func TestIndexIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue/list?first=1&order=DESC&owner=aaa&repo=bbb&states=OPEN", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Index(c)
 
@@ -191,7 +189,6 @@ func TestIndexIssueController(t *testing.T) {
 			url := "/issue/list?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
 			c.Set("token", "token")
-			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Index(c)
 
@@ -210,7 +207,6 @@ func TestGetIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue?&owner=aaa&repo=bbb&number=1", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Get(c)
 
@@ -225,7 +221,6 @@ func TestGetIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue?&owner=aaa&repo=bbb&number=1", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Get(c)
 
@@ -263,7 +258,6 @@ func TestGetIssueController(t *testing.T) {
 			url := "/issue/list?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
 			c.Set("token", "token")
-			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Get(c)
 
@@ -289,7 +283,6 @@ func TestCreateIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/issue", strings.NewReader(string(enc)))
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Create(c)
 
@@ -311,7 +304,6 @@ func TestCreateIssueController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/issue", strings.NewReader(string(enc)))
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Create(c)
 
@@ -374,7 +366,6 @@ func TestCreateIssueController(t *testing.T) {
 			c, _ := gin.CreateTestContext(res)
 			c.Request, _ = http.NewRequest(http.MethodPost, "/issue", strings.NewReader(string(enc)))
 			c.Set("token", "token")
-			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Create(c)
 

--- a/controllers/issue_controller_test.go
+++ b/controllers/issue_controller_test.go
@@ -144,6 +144,7 @@ func TestIndexIssueController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue/list?first=1&order=DESC&owner=aaa&repo=bbb&states=OPEN", nil)
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Index(c)
@@ -189,6 +190,7 @@ func TestIndexIssueController(t *testing.T) {
 			c, _ := gin.CreateTestContext(res)
 			url := "/issue/list?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
+			c.Set("token", "token")
 			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Index(c)
@@ -222,6 +224,7 @@ func TestGetIssueController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/issue?&owner=aaa&repo=bbb&number=1", nil)
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Get(c)
@@ -259,6 +262,7 @@ func TestGetIssueController(t *testing.T) {
 			c, _ := gin.CreateTestContext(res)
 			url := "/issue/list?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
+			c.Set("token", "token")
 			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Get(c)
@@ -306,6 +310,7 @@ func TestCreateIssueController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodPost, "/issue", strings.NewReader(string(enc)))
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.Create(c)
@@ -368,6 +373,7 @@ func TestCreateIssueController(t *testing.T) {
 			res := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(res)
 			c.Request, _ = http.NewRequest(http.MethodPost, "/issue", strings.NewReader(string(enc)))
+			c.Set("token", "token")
 			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.Create(c)

--- a/controllers/repo_controller.go
+++ b/controllers/repo_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"main/models"
 	"main/types"
 	"net/http"
@@ -21,14 +22,14 @@ func NewRepoController(m models.RepoModel) RepoController {
 }
 
 func (rc *repoController) IndexByToken(c *gin.Context) {
-	// headerのtokenを取得
-	token := c.GetHeader("Authorization")
-	if token == "" {
+	token, exists := c.Get("token")
+	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Error invalid authorization token",
+			"error": "Error invalid token",
 		})
 		return
 	}
+	sToken := fmt.Sprint(token)
 
 	reposReq := types.ReposReq{}
 
@@ -39,7 +40,7 @@ func (rc *repoController) IndexByToken(c *gin.Context) {
 		return
 	}
 
-	r, err := rc.m.GetReposByToken(token, reposReq)
+	r, err := rc.m.GetReposByToken(sToken, reposReq)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/controllers/repo_controller_test.go
+++ b/controllers/repo_controller_test.go
@@ -78,6 +78,7 @@ func TestIndexByTokenRepoController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/repo?first=1&order=DESC", nil)
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.IndexByToken(c)
@@ -111,6 +112,7 @@ func TestIndexByTokenRepoController(t *testing.T) {
 			c, _ := gin.CreateTestContext(res)
 			url := "/repo?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
+			c.Set("token", "token")
 			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.IndexByToken(c)

--- a/controllers/repo_controller_test.go
+++ b/controllers/repo_controller_test.go
@@ -64,7 +64,6 @@ func TestIndexByTokenRepoController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/repo?first=1&order=DESC", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.IndexByToken(c)
 
@@ -79,7 +78,6 @@ func TestIndexByTokenRepoController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/repo?first=1&order=DESC", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.IndexByToken(c)
 
@@ -113,7 +111,6 @@ func TestIndexByTokenRepoController(t *testing.T) {
 			url := "/repo?" + tc.params
 			c.Request, _ = http.NewRequest(http.MethodGet, url, nil)
 			c.Set("token", "token")
-			c.Request.Header.Set("Authorization", "Bearer")
 
 			controller.IndexByToken(c)
 

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"main/models"
 	"net/http"
 
@@ -21,25 +22,16 @@ func NewUserController(m models.UserModel) UserController {
 
 func (uc *userController) GetByToken(c *gin.Context) {
 	// auth_middlewareを使用する際の処理
-	// token, exists := c.Get("token")
-	// if !exists {
-	// 	c.JSON(http.StatusUnauthorized, gin.H{
-	// 		"error": "Error invalid token",
-	// 	})
-	// 	return
-	// }
-	// sToken := fmt.Sprint(token)
-
-	// headerのtokenを取得
-	token := c.GetHeader("Authorization")
-	if token == "" {
+	token, exists := c.Get("token")
+	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Error invalid authorization token",
+			"error": "Error invalid token",
 		})
 		return
 	}
+	sToken := fmt.Sprint(token)
 
-	u, err := uc.m.GetUserByToken(token)
+	u, err := uc.m.GetUserByToken(sToken)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -46,7 +46,6 @@ func TestGetByTokenUserController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/user", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.GetByToken(c)
 
@@ -63,7 +62,6 @@ func TestGetByTokenUserController(t *testing.T) {
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/user", nil)
 		c.Set("token", "token")
-		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.GetByToken(c)
 

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -45,7 +45,7 @@ func TestGetByTokenUserController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/user", nil)
-		// c.Set("token", "token")
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.GetByToken(c)
@@ -62,7 +62,7 @@ func TestGetByTokenUserController(t *testing.T) {
 		res := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(res)
 		c.Request, _ = http.NewRequest(http.MethodGet, "/user", nil)
-		// c.Set("token", "token")
+		c.Set("token", "token")
 		c.Request.Header.Set("Authorization", "Bearer")
 
 		controller.GetByToken(c)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      target: dev
+      target: local
     ports:
       - 8080:8080
     working_dir: /go/src/work
@@ -13,4 +13,4 @@ services:
       - .:/go/src/work
     tty: true
     environment: 
-      ENV: 'dev'  
+      ENV: 'local'  

--- a/main.go
+++ b/main.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"time"
 
+	"main/configs"
 	"main/controllers"
+	"main/middleware"
 	"main/models"
 	"main/utils"
 
@@ -16,9 +18,16 @@ import (
 var r *gin.Engine
 
 func init() {
-	if os.Getenv("ENV") == "dev" {
+	host := ""
+	if os.Getenv("ENV") == "local" {
 		utils.InitEnv()
+		host = configs.GetLocalHost()
+	} else {
+		host = configs.GetHost()
 	}
+
+	authModel := models.NewAuthModel()
+	authController := controllers.NewAuthController(authModel)
 
 	userModel := models.NewUserModel()
 	userController := controllers.NewUserController(userModel)
@@ -34,7 +43,7 @@ func init() {
 	// cors設定
 	r.Use(cors.New(cors.Config{
 		AllowOrigins: []string{
-			"*",
+			host,
 		},
 		AllowMethods: []string{
 			"GET",
@@ -56,13 +65,30 @@ func init() {
 		c.JSON(http.StatusOK, "Welcome Github API Wrapper!")
 	})
 
+	auth := api.Group("/auth")
+	{
+		auth.GET("", authController.Get)
+		// local開発用のTokenを返す
+		auth.GET("/test", func(c *gin.Context) {
+			cookie := &http.Cookie{
+				Name:  "Token",
+				Value: os.Getenv("ACCESS_TOKEN"), Path: "/",
+				Expires: time.Now().Add(24 * time.Hour),
+			}
+			http.SetCookie(c.Writer, cookie)
+			c.JSON(http.StatusOK, "Github API Local Token!")
+		})
+	}
+
 	viewer := api.Group("/viewer")
+	viewer.Use(middleware.ParseAuthHandler())
 	{
 		viewer.GET("/user", userController.GetByToken)
 		viewer.GET("/repos", repoController.IndexByToken)
 	}
 
 	issue := api.Group("/issue")
+	issue.Use(middleware.ParseAuthHandler())
 	{
 		issue.GET("/list", issueController.Index)
 		issue.GET("", issueController.Get)

--- a/main.go
+++ b/main.go
@@ -71,9 +71,11 @@ func init() {
 		// local開発用のTokenを返す
 		auth.GET("/test", func(c *gin.Context) {
 			cookie := &http.Cookie{
-				Name:  "Token",
-				Value: os.Getenv("ACCESS_TOKEN"), Path: "/",
-				Expires: time.Now().Add(24 * time.Hour),
+				Name:     "Token",
+				Value:    os.Getenv("ACCESS_TOKEN"),
+				Path:     "/",
+				Expires:  time.Now().Add(24 * time.Hour),
+				HttpOnly: true,
 			}
 			http.SetCookie(c.Writer, cookie)
 			c.JSON(http.StatusOK, "Github API Local Token!")

--- a/models/auth.go
+++ b/models/auth.go
@@ -1,0 +1,69 @@
+package models
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"main/configs"
+	"main/types"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type AuthModel interface {
+	GetToken(types.AuthReq) (types.AuthRes, error)
+}
+
+type authModel struct{}
+
+func NewAuthModel() AuthModel {
+	return &authModel{}
+}
+
+func (am *authModel) GetToken(authReq types.AuthReq) (types.AuthRes, error) {
+	authRes := types.AuthRes{}
+
+	val := make(map[string]string)
+
+	val["client_id"] = os.Getenv("CLIENT_ID")
+	val["client_secret"] = os.Getenv("CLIENT_SECRET")
+	val["code"] = authReq.Code
+
+	data, err := json.Marshal(val)
+	if err != nil {
+		log.Println("Error marshal query json:", err)
+		return authRes, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, configs.GetGithubAccessTokenEndPoint(), strings.NewReader(string(data)))
+	if err != nil {
+		log.Println("Error request github api:", err)
+		return authRes, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		log.Println("Error do client:", err)
+		return authRes, err
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Println("Error reading body:", err)
+		return authRes, err
+	}
+
+	json.Unmarshal(body, &authRes)
+
+	return authRes, nil
+}

--- a/models/auth_test.go
+++ b/models/auth_test.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"main/utils"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetTokenAuthModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	utils.InitEnv()
+
+	// GetTokenは一時コードが必要なため、テストは行わない
+	// 雛形だけ作成
+	t.Run("Test with success response", func(t *testing.T) {
+		// authReq := types.AuthReq{
+		// 	Code: "abcd12345", //一時コード
+		// }
+
+		// model := NewAuthModel()
+
+		// _, err := model.GetToken(authReq)
+		// if err != nil {
+		// 	t.Errorf("GetIssues returned an error: %v", err)
+		// }
+	})
+}

--- a/models/issue.go
+++ b/models/issue.go
@@ -68,7 +68,7 @@ func (im *issueModel) GetIssues(token string, issuesReq types.IssuesReq) (types.
 	}
 
 	req.Header.Set("Authorization", token)
-	req.Header.Set("Context-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -144,7 +144,7 @@ func (im *issueModel) GetIssue(token string, issueReq types.IssueReq) (types.Iss
 	}
 
 	req.Header.Set("Authorization", token)
-	req.Header.Set("Context-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -205,7 +205,7 @@ func (im *issueModel) CreateIssue(token string, issueCreateReq types.IssueCreate
 	}
 
 	req.Header.Set("Authorization", token)
-	req.Header.Set("Context-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/models/repo.go
+++ b/models/repo.go
@@ -59,7 +59,7 @@ func (rm *repoModel) GetReposByToken(token string, reposReq types.ReposReq) (typ
 	}
 
 	req.Header.Set("Authorization", token)
-	req.Header.Set("Context-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/models/user.go
+++ b/models/user.go
@@ -49,7 +49,7 @@ func (um *userModel) GetUserByToken(token string) (types.UserRes, error) {
 	}
 
 	req.Header.Set("Authorization", token)
-	req.Header.Set("Context-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/types/auth.go
+++ b/types/auth.go
@@ -1,0 +1,11 @@
+package types
+
+type AuthReq struct {
+	Code string `form:"code" binding:"required"`
+}
+
+type AuthRes struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}


### PR DESCRIPTION
# Issue
#36

# 概要
一時コードからOAuthAccessTokenを取得する処理の作成する。
クライアントから一時コードを受け取り、GIthubAPIにリクエストを送る
graphQLは実装されていないため、
> https://github.com/login/oauth/access_token

上記エンドポイントにPOSTし、OAuthAccessTokenを取得する
取得したtokenはcookieに保管され、データを取得する際に使用する
cookieからトークン取得する処理はauth_middlewareで行なっている

# 備考
headerからではなく、cookieから取得するように変更したため、
トークンを取得する処理を変更

開発環境と区別する変数をdevからlocalに変更
誤字の修正を含みます